### PR TITLE
Scaffold out re-usable tutorial layout and dynamic routing. Add style…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,17 +73,6 @@
       "resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",
       "integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg=="
     },
-    "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-      "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
-      }
-    },
     "ajv-keywords": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
@@ -3115,6 +3104,17 @@
         "text-table": "~0.2.0"
       },
       "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -3151,6 +3151,11 @@
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
           "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
         },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+        },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -3164,6 +3169,11 @@
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
           }
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
         },
         "strip-ansi": {
           "version": "4.0.0",
@@ -3628,11 +3638,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
-    "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -4663,6 +4668,29 @@
       "requires": {
         "ajv": "^5.1.0",
         "har-schema": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+        }
       }
     },
     "has": {
@@ -5921,11 +5949,6 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
-    "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -8730,6 +8753,29 @@
       "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
       "requires": {
         "ajv": "^5.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+        }
       }
     },
     "select-hose": {
@@ -8911,6 +8957,11 @@
       "requires": {
         "is-fullwidth-code-point": "^2.0.0"
       }
+    },
+    "slugify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.3.0.tgz",
+      "integrity": "sha512-vvz+9ANt7CtdTHwJpfrsHOnGkgxky+CUPnvtzDZBZYFo/H/CdZkd5lJL7z7RqtH/x9QW/ItYYfHlcGf38CBK1w=="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -10280,6 +10331,17 @@
         "yargs": "^8.0.2"
       },
       "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
         "ajv-keywords": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
@@ -10312,6 +10374,11 @@
             }
           }
         },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+        },
         "has-flag": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
@@ -10324,6 +10391,11 @@
           "requires": {
             "number-is-nan": "^1.0.0"
           }
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
         },
         "load-json-file": {
           "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "react-dom": "^16.4.1",
     "react-router-dom": "^4.3.1",
     "react-scripts": "1.1.4",
+    "slugify": "^1.3.0",
     "styled-components": "^3.3.3"
   },
   "scripts": {

--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,38 @@
+// Dependencies
 import React, { Component } from 'react';
-import styled from 'styled-components';
+import { BrowserRouter as Router, Route } from 'react-router-dom';
+
+// Styled Components
+import { PageWrapper, Header, Main, Workspace } from './styles';
+
+// Components
+import SideBar from './components/SideBar';
+import PageTemplate from './components/PageTemplate';
+
+// Page Data & Routes
+import pages from './page-data';
 
 export default class App extends Component {
   render() {
     return (
-      <div>
-          <h1>Styled Components & Atomic Design</h1>
-      </div>
+        <PageWrapper>
+            <Header>
+              <h1><span>Styled Components &</span> <span>Atomic Design Tutorial</span></h1>
+            </Header>
+            <Router>
+              <Main>
+                <SideBar pages={pages} />
+                <Workspace>
+                  {
+                    /* Dynamically Generate Routes with Page Component Template and pass the page object information along as props */
+                    pages.map(page => {
+                      return  <Route key={page.id} path={page.route} component={()=><PageTemplate {...page}/>}/>
+                    })
+                  }
+                </Workspace>
+              </Main>
+            </Router>
+        </PageWrapper>
     );
   }
 }

--- a/src/components/PageTemplate.js
+++ b/src/components/PageTemplate.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { PageHeader, PageDescription } from '../styles';
+
+const PageTemplate = (props) =>
+  <div>
+    <PageHeader>{ props.title }</PageHeader>
+    <PageDescription>{ props.description }</PageDescription>
+  </div>
+
+export default PageTemplate;

--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { SideBarWrapper } from '../styles';
+import SideBarItem from './SideBarItem';
+
+ const SideBar = ({pages}) =>
+  <SideBarWrapper>
+    <ul>
+      { pages.map((page,index)=>
+        <SideBarItem key={index} to={page.route}>{page.title}</SideBarItem>
+      )}
+    </ul>
+  </SideBarWrapper>
+
+export default SideBar;

--- a/src/components/SideBarItem.js
+++ b/src/components/SideBarItem.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { SideBarText, StyledLink } from '../styles';
+
+const SideBarItem = (props) =>
+  <StyledLink to={ props.to }>
+     <li>
+         <SideBarText>{ props.children }</SideBarText>
+     </li>
+   </StyledLink>
+
+export default SideBarItem;

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,40 @@
-body {
+/* Resets */
+
+body, h1, h2 {
   margin: 0;
+  font-family: sans-serif;
+}
+
+ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+a {
+  text-decoration: none;
+  color: inherit;
+}
+
+/* Animations */
+
+@keyframes slide-in {
+  from {
+    max-width: 1px;
+  }
+  to{
+    max-width: 100%;
+  }
+}
+
+@keyframes skew-in {
+  from {
+    background: #87ace5;
+    transform: translateX(-5px) translateY(0) skewY(0deg);
+  }
+  to{
+    opacity: 1;
+    background: #d4e4fc;
+    transform: translateX(0) translateY(4px) skewY(40deg);
+  }
 }

--- a/src/page-data.js
+++ b/src/page-data.js
@@ -1,0 +1,53 @@
+import slugify from 'slugify';
+
+/*
+
+Static source of data to populate tutorial steps and page content. A slug will be generated automatically for each page. Page titles should be unique.
+
+*/
+
+const ABOUT = {
+  title: 'About This Tutorial',
+  description: '',
+  steps: [ ],
+}
+
+const ATOMIC_DESIGN = {
+  title: 'Brief Introduction to Atomic Design',
+  description: '',
+  steps: [ ],
+}
+
+const STYLED_COMPONENTS = {
+  title: 'Using Styled Components',
+  description: '',
+  steps: [ ],
+}
+
+const ATOMS = {
+  title: 'Creating Atoms',
+  description: '',
+  steps: [ ],
+}
+
+const MOLECULES = {
+  title: 'Creating Molecules',
+  description: '',
+  steps: [ ],
+}
+
+const ORGANISMS = {
+  title: 'Creating Organisms',
+  description: '',
+  steps: [ ],
+}
+
+function addSlugAndId(page, index){
+  page.id = `page_${index}`;
+  page.route = `/${slugify(page.title).toLowerCase()}`;
+  return page;
+}
+
+const pages = [ ABOUT, ATOMIC_DESIGN, STYLED_COMPONENTS, ATOMS, MOLECULES, ORGANISMS ].map(addSlugAndId);
+
+export default pages;

--- a/src/styles.js
+++ b/src/styles.js
@@ -1,0 +1,137 @@
+// Dependencies
+import styled from 'styled-components';
+import { NavLink } from 'react-router-dom';
+
+// Colors
+const DARK_BLUE = '#516789';
+const DARK_BLUE_ALT = '#87ace5';
+const MED_BLUE = '#84b3ff';
+const LIGHT_BLUE = '#c1ecff';
+const WHITE_LAYER = `rgba(255,255,255,0.4)`;
+
+// Page
+export const PageWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+// Header
+export const Header = styled.header`
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  height: 90px;
+  background: ${ MED_BLUE };
+  color: white;
+  text-shadow: 1px 1px 1px rgba(0,0,0,0.5);
+  border-bottom: 5px solid rgba(0,0,0,0.7);
+  h1 {
+    margin-left: 30px;
+    margin-right: 30px;
+  }
+  @media (max-width: 760px){
+    font-size: 0.8em;
+    span {
+      display: inline-block;
+    }
+  }
+`;
+
+// Main Area (Everything South of the Header)
+export const Main = styled.div`
+  display: flex;
+  height: calc(100vh - 90px);
+`;
+
+// SideBar
+
+export const SideBarWrapper = styled.div`
+  width: 320px;
+  background: ${ DARK_BLUE };
+  color: white;
+  box-sizing: border-box;
+  padding-top: 30px;
+  border-right: solid ${ WHITE_LAYER } 10px;
+  ul {
+    &:nth-child(1){
+      margin-top: -15px;
+    }
+  }
+  li {
+    display: block;
+    padding: 15px 30px;
+    cursor: pointer;
+    position: relative;
+    transform-origin: bottom;
+    &:hover span {
+      border-bottom: 1px solid rgba(255,255,255,1);
+    }
+    &:hover {
+      background-image: linear-gradient(
+        ${ WHITE_LAYER },
+        ${ WHITE_LAYER });
+    }
+  }
+`;
+
+export const SideBarText = styled.span`
+  border-bottom: 1px solid ${ WHITE_LAYER };
+  display: inline-block;
+  line-height: 0.95;
+  transform-origin: top left;
+  transition: transform 0.1s;
+  text-shadow: 1px 1px 2px black;
+`;
+
+export const StyledLink = styled(NavLink)`
+  &.active {
+    li {
+      filter:drop-shadow(-2px 3px 1px rgba(0,0,0,0.3));
+      span {
+        border-bottom: 1px solid rgba(255,255,255,1);
+      }
+      &::before {
+        content: '';
+        left:0;
+        top: 0;
+        z-index: -1;
+        animation: slide-in 0.2s;
+        display: block;
+        position: absolute;
+        width: 100%;
+        height: calc(100%);
+        background: ${ DARK_BLUE_ALT };
+      }
+      &::after {
+        content: '';
+        display: block;
+        position: absolute;
+        right: -10px;
+        top: 0px;
+        width: 10px;
+        height: calc(100%);
+        transform: translateY(4px) skewY(40deg);
+        animation: skew-in 0.3s 0.2s forwards;
+      }
+    }
+  }
+`;
+
+// Workspace
+export const Workspace = styled.div`
+  flex: 1;
+  background: ${LIGHT_BLUE};
+  background-image:
+    linear-gradient(to right,
+      rgba(0,0,0,0.1) 0px,
+      transparent 5px,
+      transparent 0);
+`;
+
+// Page Template
+export const PageHeader = styled.h2`
+  padding: 30px;
+`;
+
+export const PageDescription = styled.p`
+`;


### PR DESCRIPTION
Deployed to GitHub Pages, but not yet merged...
[example of latest changes @ gh-pages](https://wobbly-app.github.io/tutorial)

Adds a basic structure and styles for a re-usable tutorial template.

Have not yet added any actual additional steps or content. But my idea is that there would be tutorial steps in a side bar (perhaps expandable to another level deep with more specific steps) and then a main area with detailed instructions and within that area a separate area designated for a user editable component to render out.

The tutorial follower would update this component (or create and import building block components into this main component) and then it would render in the main area of the tutorial view so they could read steps, follow along, yet create their changes within the actual tutorial source itself.

I think a template like this could work well for any number of tutorials related to the project technical or otherwise and the page data file is pretty easy to edit for people of all technical abilities. I added a function so that route paths are updated dynamically and page slugs are built from page titles passed to the `page-data.js` file.

**Example Page/Step Data**

```
const STYLED_COMPONENTS = {
  title: 'Using Styled Components',
  description: 'Learn how to use styled components',
  steps: ['Description of step 1', 'Description of step 2', ...etc],
  route: <created automatically from title>,
  id: <created automatically from index order>
}
```

Please let me know if anything is unclear! Or if you all have suggestions for how to proceed or improve things I am all ears :)

Next steps would probably be gathering a brief overview on Atomic Design, Styled Components, and then doing a bit more styling, editing, and page-data parsing so the PageTemplate component can render everything out nicely. Some way of tracking progress in the tutorial could be pretty cool, but not exactly sure how to implement that.