### PR TITLE
Add Markdown-to-JSX for Rendering Page Content via Markdown Files.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -341,6 +341,15 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
       "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
     },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
+      }
+    },
     "axobject-query": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-0.1.0.tgz",
@@ -6300,6 +6309,15 @@
         "object-visit": "^1.0.0"
       }
     },
+    "markdown-to-jsx": {
+      "version": "6.6.9",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.6.9.tgz",
+      "integrity": "sha1-0a/qOzGUs8nwrM8ruyuFlN5GdI0=",
+      "requires": {
+        "prop-types": "^15.5.10",
+        "unquote": "^1.1.0"
+      }
+    },
     "math-expression-evaluator": {
       "version": "1.2.17",
       "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
@@ -10020,6 +10038,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "unquote": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
+      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
     },
     "unset-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "homepage": "http://Wobbly-App.github.io/tutorial",
   "dependencies": {
+    "axios": "^0.18.0",
+    "markdown-to-jsx": "^6.6.9",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
     "react-router-dom": "^4.3.1",

--- a/src/components/PageTemplate.js
+++ b/src/components/PageTemplate.js
@@ -1,10 +1,29 @@
-import React from 'react';
-import { PageHeader, PageDescription } from '../styles';
+import React, { Component } from 'react';
+import { MarkdownWrapper } from '../styles';
+import Markdown from 'markdown-to-jsx';
+import axios from 'axios';
 
-const PageTemplate = (props) =>
-  <div>
-    <PageHeader>{ props.title }</PageHeader>
-    <PageDescription>{ props.description }</PageDescription>
-  </div>
+class PageTemplate extends Component {
+
+  state = {
+    markdown: ''
+  }
+
+  // async call to fetch markdown file and set markdown string to state
+  async componentDidMount(){
+    const getMarkdown = axios.get(this.props.md_path);
+    const markdown = await getMarkdown;
+    this.setState({markdown: markdown.data});
+  }
+
+  render(){
+    const { markdown } = this.state;
+    return (
+      <MarkdownWrapper>
+        <Markdown>{markdown}</Markdown>
+      </MarkdownWrapper>
+    )
+  }
+}
 
 export default PageTemplate;

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,0 +1,22 @@
+import slugify from 'slugify';
+
+export const addSlugAndId = (page, index) => {
+  page.id = `page_${index}`;
+  page.route = `/tutorial/${slugify(page.title).toLowerCase()}`;
+  return page;
+}
+
+export const validateUniquePageTitle = (pages) => {
+  const unique = [];
+  pages.forEach((page, index)=> {
+    try {
+      if(!unique.includes(page.title)){
+        unique.push(page.title);
+      }else{
+        throw new Error(`Duplicate title found. Please check the title prop: "${page.title}" at index ${index} in the pages array.`)
+      }
+    } catch(err){
+      throw err
+    }
+  })
+}

--- a/src/md-pages/ABOUT.md
+++ b/src/md-pages/ABOUT.md
@@ -1,0 +1,2 @@
+## About This Tutorial
+This tutorial will give you a brief overview of how we're using Styled Components and Atomic Design at Wobbly.

--- a/src/md-pages/ATOMIC_DESIGN.md
+++ b/src/md-pages/ATOMIC_DESIGN.md
@@ -1,0 +1,1 @@
+## Brief Introduction to Atomic Design

--- a/src/md-pages/ATOMS.md
+++ b/src/md-pages/ATOMS.md
@@ -1,0 +1,1 @@
+## Creating Atoms

--- a/src/md-pages/MOLECULES.md
+++ b/src/md-pages/MOLECULES.md
@@ -1,0 +1,1 @@
+## Creating Molecules

--- a/src/md-pages/ORGANISMS.md
+++ b/src/md-pages/ORGANISMS.md
@@ -1,0 +1,1 @@
+## Creating Organisms

--- a/src/md-pages/STYLED_COMPONENTS.md
+++ b/src/md-pages/STYLED_COMPONENTS.md
@@ -1,0 +1,1 @@
+## Using Styled Components

--- a/src/page-data.js
+++ b/src/page-data.js
@@ -44,7 +44,7 @@ const ORGANISMS = {
 
 function addSlugAndId(page, index){
   page.id = `page_${index}`;
-  page.route = `/${slugify(page.title).toLowerCase()}`;
+  page.route = `/tutorial/${slugify(page.title).toLowerCase()}`;
   return page;
 }
 

--- a/src/page-data.js
+++ b/src/page-data.js
@@ -1,53 +1,80 @@
-import slugify from 'slugify';
-
 /*
 
-Static source of data to populate tutorial steps and page content. A slug will be generated automatically for each page. Page titles should be unique.
+/// HOW TO USE THIS FILE ///
+
+This file is a static source used to export an array of page data that populates tutorial page content. Thought it might be useful to handle page content by converting markdown files into components via markdown-to-jsx. The page objects take a title (title) and a markdown path (md_path). Duplicate page titles are forbidden, if you attempt to create a non-unique page title an error will be thrown. A slug will be generated automatically for each page prior to export so there's no need to worry about route names.
+
+Step 1: Import the markdown file path.
+
+Step 2: Create a new object with a unique title and set the corresponding markdown path (i.e. md_path property).
+
+Step 3: Add the page object to the pages array so slugs and ids will be generated prior to export.
+
+*** Potentially Helpful Conventions ***
+
+To avoid confusion markdown file names and page objects should be in all caps.
+Markdown file paths should be imported in lowercase and appended with '_path'.
 
 */
 
+// Functions
+import { addSlugAndId, validateUniquePageTitle } from './helpers';
+
+// Import Markdown file paths
+
+import about_path from './md-pages/ABOUT.md';
+import atomic_design_path from './md-pages/ATOMIC_DESIGN.md';
+import styled_components_path from './md-pages/STYLED_COMPONENTS.md';
+import atoms_path from './md-pages/ATOMS.md';
+import molecules_path from './md-pages/MOLECULES.md';
+import organisms_path from './md-pages/ORGANISMS.md';
+
+// Create Page Objects
+
 const ABOUT = {
   title: 'About This Tutorial',
-  description: '',
-  steps: [ ],
+  md_path: about_path,
 }
 
 const ATOMIC_DESIGN = {
   title: 'Brief Introduction to Atomic Design',
-  description: '',
-  steps: [ ],
+  md_path: atomic_design_path,
 }
 
 const STYLED_COMPONENTS = {
   title: 'Using Styled Components',
-  description: '',
-  steps: [ ],
+  md_path: styled_components_path,
 }
 
 const ATOMS = {
   title: 'Creating Atoms',
-  description: '',
-  steps: [ ],
+  md_path: atoms_path,
 }
 
 const MOLECULES = {
   title: 'Creating Molecules',
-  description: '',
-  steps: [ ],
+  md_path: molecules_path,
 }
 
 const ORGANISMS = {
   title: 'Creating Organisms',
-  description: '',
-  steps: [ ],
+  md_path: organisms_path,
 }
 
-function addSlugAndId(page, index){
-  page.id = `page_${index}`;
-  page.route = `/tutorial/${slugify(page.title).toLowerCase()}`;
-  return page;
-}
+// Add Objects to pages array
+const pages = [
+  ABOUT,
+  ATOMIC_DESIGN,
+  STYLED_COMPONENTS,
+  ATOMS,
+  MOLECULES,
+  ORGANISMS
+];
 
-const pages = [ ABOUT, ATOMIC_DESIGN, STYLED_COMPONENTS, ATOMS, MOLECULES, ORGANISMS ].map(addSlugAndId);
+// Validate Pages for the Presence of Unique Titles
+validateUniquePageTitle(pages);
 
-export default pages;
+// Generate page slug and id for each page object
+const slugifiedPages = pages.map(addSlugAndId);
+
+export default slugifiedPages;

--- a/src/styles.js
+++ b/src/styles.js
@@ -129,9 +129,6 @@ export const Workspace = styled.div`
 `;
 
 // Page Template
-export const PageHeader = styled.h2`
+export const MarkdownWrapper = styled.div`
   padding: 30px;
-`;
-
-export const PageDescription = styled.p`
 `;


### PR DESCRIPTION
Thought it might be fun to add the ability to parse markdown files and convert them into react components. This way page content can be created and styled in a separate directory by non-technical contributors or contributors less familiar with our tech stack. Will also help to keep pages a bit more separated and organized so we're not having to muck around in a single JS export to generate or edit site content. 

**Summary of Changes**
- Added Validation for Enforcing Unique Page Titles.
- Moved Page Body Content to individual markdown files in the `/md-pages` Directory
- Documented Instructions for Usage in the `page-data.js` file.
- Fixed a routing error 